### PR TITLE
internal/syscall/windows/registry: change ReadSubKeyNames signature to iterator

### DIFF
--- a/src/internal/syscall/windows/registry/registry_test.go
+++ b/src/internal/syscall/windows/registry/registry_test.go
@@ -35,7 +35,11 @@ func TestReadSubKeyNames(t *testing.T) {
 	}
 	defer k.Close()
 
-	names, err := k.ReadSubKeyNames()
+	names := make([]string, 0)
+	err = k.ReadSubKeyNames(func(s string) error {
+		names = append(names, s)
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/mime/type_windows.go
+++ b/src/mime/type_windows.go
@@ -13,10 +13,15 @@ func init() {
 }
 
 func initMimeWindows() {
-	names, err := registry.CLASSES_ROOT.ReadSubKeyNames()
+	names := make([]string, 0)
+	err := registry.CLASSES_ROOT.ReadSubKeyNames(func(s string) error {
+		names = append(names, s)
+		return nil
+	})
 	if err != nil {
 		return
 	}
+
 	for _, name := range names {
 		if len(name) < 2 || name[0] != '.' { // looking for extensions only
 			continue

--- a/src/time/zoneinfo_windows.go
+++ b/src/time/zoneinfo_windows.go
@@ -67,7 +67,11 @@ func toEnglishName(stdname, dstname string) (string, error) {
 	}
 	defer k.Close()
 
-	names, err := k.ReadSubKeyNames()
+	names := make([]string, 0)
+	err = k.ReadSubKeyNames(func(s string) error {
+		names = append(names, s)
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Key.ReadSubKeyNames returns a slice of strings, which is not very 
efficient for iteration. Since we want to introduce users/groups
iteration for os/user, we need to make sure that iteration process
is memory efficient. For os/user iteration functionality, 
Key.ReadSubKeyNames is used to retrieve windows SIDs from registry. 
As it is possible to have arbitrary number of SIDs, rather than allocating
a slice for all possible SIDs, a better approach is to provide iterator
callback function, which receives each SID.